### PR TITLE
Fix haskell-snippets dir.

### DIFF
--- a/haskell-snippets.el
+++ b/haskell-snippets.el
@@ -69,8 +69,7 @@
 ;;; Code:
 
 (setq haskell-snippets-dir
-      (file-name-directory (or (buffer-file-name)
-                               load-file-name)))
+      (file-name-directory load-file-name))
 
 ;;;###autoload
 (defun haskell-snippets-initialize ()


### PR DESCRIPTION
Using buffer-file-name will append a path relative to the visited
buffer to yas-snippet-dirs if yas-global-mode is activated from
within an arbitrary buffer.

Fixes #1.
