### PR TITLE
Sub-directories under src and type arguments to newtypes

### DIFF
--- a/snippets/haskell-mode/module
+++ b/snippets/haskell-mode/module
@@ -6,9 +6,12 @@
 # contributor: Luke Hoersten <luke@hoersten.org>
 # --
 module ${1:`(if (not buffer-file-name) "Module"
-                (let ((name (file-name-sans-extension (buffer-file-name))))
+                (let ((name (file-name-sans-extension (buffer-file-name)))
+                      (case-fold-search nil))
                      (if (search "src/" name)
-                         (replace-regexp-in-string "/" "." (car (last (split-string name "src/"))))
-                         (file-name-nondirectory name))))`} where
+                         (replace-regexp-in-string "/" "."
+                           (replace-regexp-in-string "^\/[^A-Z]*" ""
+                             (car (last (split-string name "src")))))
+                         (File-Name-nondirectory name))))`} where
 
 $0

--- a/snippets/haskell-mode/module.exports
+++ b/snippets/haskell-mode/module.exports
@@ -6,9 +6,12 @@
 # contributor: Luke Hoersten <luke@hoersten.org>
 # --
 module ${1:`(if (not buffer-file-name) "Module"
-                (let ((name (file-name-sans-extension (buffer-file-name))))
+                (let ((name (file-name-sans-extension (buffer-file-name)))
+                      (case-fold-search nil))
                      (if (search "src/" name)
-                         (replace-regexp-in-string "/" "." (car (last (split-string name "src/"))))
+                         (replace-regexp-in-string "/" "."
+                           (replace-regexp-in-string "^\/[^A-Z]*" ""
+                             (car (last (split-string name "src")))))
                          (file-name-nondirectory name))))`}
     ( ${3:export}
     ${4:, ${5:export}}

--- a/snippets/haskell-mode/newtype
+++ b/snippets/haskell-mode/newtype
@@ -4,4 +4,4 @@
 # condition: (= (length "new") (current-column))
 # contributor: Luke Hoersten <luke@hoersten.org>
 # --
-newtype ${1:Type} = $1 { un$1 :: ${2:a} } ${3:deriving (${4:Show, Eq})}
+newtype ${1:Type} ${2:a} = $1 { un$1 :: ${3:a} } ${4:deriving (${5:Show, Eq})}


### PR DESCRIPTION
If you have sub-directories under `src`, this will remove those from the module name.

Previously, if you were modifying `path/to/pkg/src/lib/ModuleName.hs`, the module snippets would produce `module lib.ModuleName where`. This fix removes `lib.`

I also added a type argument to newtypes, just because I found that I was often going back and adding type arguments to my newtypes whenever I used this snippet.
