### PR TITLE
Fix function name spelling

### DIFF
--- a/snippets/haskell-mode/module
+++ b/snippets/haskell-mode/module
@@ -12,6 +12,6 @@ module ${1:`(if (not buffer-file-name) "Module"
                          (replace-regexp-in-string "/" "."
                            (replace-regexp-in-string "^\/[^A-Z]*" ""
                              (car (last (split-string name "src")))))
-                         (File-Name-nondirectory name))))`} where
+                         (file-name-nondirectory name))))`} where
 
 $0


### PR DESCRIPTION
Original spelling yields a void symbol error in Emacs 27:

```
module Symbol’s function definition is void: File-Name-nondirectory where
```